### PR TITLE
Fix deprecation warning for Silex 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ matrix:
   include:
     - php: 5.5.9
       env: MINIMAL_DEPENDENCIES=true
+      dist: trusty
     - php: 5.5
+      dist: trusty
     - php: 5.6
     - php: 7.0
     - php: 7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+# TBD
+
+### Bug Fixes
+
+* Fix deprecation warning for Silex 2.3.0
+  [#28](https://github.com/bugsnag/bugsnag-silex/pull/28)
+
 ## 2.5.0 (2019-06-26)
 
 ### Enhancements

--- a/src/Request/SilexRequest.php
+++ b/src/Request/SilexRequest.php
@@ -43,7 +43,10 @@ class SilexRequest implements RequestInterface
      */
     public function getSession()
     {
-        $session = $this->request->getSession();
+        $session = null;
+        if ($this->request->hasSession()) {
+            $session = $this->request->getSession();
+        }
 
         return $session ? $session->all() : [];
     }


### PR DESCRIPTION
## Goal

Fixes deprecation warning when calling `request->getSession` if the session doesn't exist. (This is the same fix as was applied in bugsnag/bugsnag-symfony#79.)

## Changeset

### Changed

* SilexRequest - guarded call to `getSession`

## Tests

Re-ran example project with Silex 2.3.

### Linked issues

Fixes bugsnag/bugsnag-php#518

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
